### PR TITLE
Ensure tests fail when there are leaks.

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -130,7 +130,11 @@ function _browserifyBundle() {
 
 function _mocha() {
   return gulp.src(['test/setup/node.js', 'test/unit/**/*.js'], {read: false})
-    .pipe($.mocha({reporter: 'dot', globals: config.mochaGlobals}));
+    .pipe($.mocha({
+      reporter: 'dot',
+      globals: config.mochaGlobals,
+      ignoreLeaks: false
+    }));
 }
 
 function _registerBabel() {


### PR DESCRIPTION
Resolves #196 

Tested in Node 4.0.0 and 0.12.0. In both environments the tests failed with good errors, as in: 

```sh
Jamess-MacBook:generator-tests jmeas$ npm run test

> generator-tests@0.0.1 test /Users/jmeas/WebDev/temp/generator-tests
> gulp

[18:08:59] Requiring external module babel-core/register
[DEPRECATION NOTICE] Esperanto is no longer under active development. To convert an ES6 module to another format, consider using Babel (https://babeljs.io)
[18:09:00] Using gulpfile ~/WebDev/temp/generator-tests/gulpfile.babel.js
[18:09:00] Starting 'lint-src'...
[18:09:01] Starting 'lint-test'...
[18:09:02] Finished 'lint-src' after 1.6 s
[18:09:02] Finished 'lint-test' after 575 ms
[18:09:02] Starting 'test'...


  ․․․․

  2 passing (29ms)
  2 failing

  1) generatorTests Greet function "before each" hook:
     Error: global leak detected: sandwich
  

  2) generatorTests Greet function should have been run once:
     Error: global leak detected: expectations
  



[18:09:02] 'test' errored after 352 ms
[18:09:02] Error in plugin 'gulp-mocha'
Message:
    2 tests failed.
```