### PR TITLE
Fixes a bug where the watch task could crash.

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -93,7 +93,7 @@ function build(done) {
 
 function _runBrowserifyBundle(bundler) {
   return bundler.bundle()
-    .on('error', err => {
+    .on('error', function(err) {
       $.util.log($.util.colors.red.bold(err.message));
       this.emit('end');
     })


### PR DESCRIPTION
We were accidentally binding the context of the function. Luckily, this was never released!

Resolves #249