### PR TITLE
Remove redundant settings in test/eslintrc

### DIFF
--- a/app/templates/test/eslintrc
+++ b/app/templates/test/eslintrc
@@ -1,8 +1,6 @@
 {
   "parser": "babel-eslint",
   "rules": {
-    "strict": 0,
-    "quotes": [2, "single"],
     "no-unused-expressions": 0
   },
   "env": {


### PR DESCRIPTION
These are already inherited from ./eslintrc
