### PR TITLE
Create centralized globals.json for test globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,4 @@ If you want to access the module itself in your unit test files, you will need t
 test environment to support the module. To do this:
 
 1. Load the module in the [test setup file](https://github.com/babel/generator-babel-boilerplate/blob/master/test/setup/setup.js).
-  Attach any exported variables to global object if you'll be using them in your tests.
-2. Add those same global variables to the `mochaGlobals` array in `package.json` under
-  `babelBoilerplateOptions`
+2. Add any exported variables to globals object in the [test globals json](https://github.com/babel/generator-babel-boilerplate/blob/master/test/setup/.globals.js).

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -54,10 +54,6 @@
   },
   "babelBoilerplateOptions": {
     "entryFileName": "<%= repo %>",
-    "mainVarName": "<%= variable %>",
-    "mochaGlobals": [
-      "stub", "spy", "expect", "sandbox", "mock",
-      "useFakeTimers", "useFakeXMLHttpRequest", "useFakeServer"
-    ]
+    "mainVarName": "<%= variable %>"
   }
 }

--- a/app/templates/test/.eslintrc
+++ b/app/templates/test/.eslintrc
@@ -1,4 +1,5 @@
 {
+  extends: "./setup/.globals.json",
   "parser": "babel-eslint",
   "rules": {
     "strict": 0,
@@ -9,14 +10,5 @@
     "browser": true,
     "node": true,
     "mocha": true
-  },
-  "globals": {
-    "spy": true,
-    "stub": true,
-    "mock": true,
-    "useFakeTimers": true,
-    "useFakeXMLHttpRequest": true,
-    "useFakeServer": true,
-    "expect": true
   }
 }

--- a/app/templates/test/setup/.globals.json
+++ b/app/templates/test/setup/.globals.json
@@ -1,0 +1,12 @@
+{
+  "globals": {
+    "expect": true,
+    "mock": true,
+    "sandbox": true,
+    "spy": true,
+    "stub": true,
+    "useFakeServer": true,
+    "useFakeTimers": true,
+    "useFakeXMLHttpRequest": true
+  }
+}

--- a/app/templates/test/setup/browser.js
+++ b/app/templates/test/setup/browser.js
@@ -1,9 +1,9 @@
-var config = require('../../package.json').babelBoilerplateOptions;
++var mochaGlobals = require('./.globals.json').globals;
 
 window.mocha.setup('bdd');
 window.onload = function() {
   window.mocha.checkLeaks();
-  window.mocha.globals(config.mochaGlobals);
+  window.mocha.globals(Object.keys(mochaGlobals));
   window.mocha.run();
   require('./setup')(window);
 };


### PR DESCRIPTION
Create centralized `.globals.json` for test globals

Removes the need to update two objects.  It's too easy to update one and for get the other. It wasn't consistent as it was.

And it's in the `test/setup` directory which seems pretty self explanatory.