### PR TITLE
Fix for incorrect isparta import in gulpfile.babel.js

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -3,7 +3,7 @@ import loadPlugins from 'gulp-load-plugins';
 import del  from 'del';
 import glob  from 'glob';
 import path  from 'path';
-import isparta  from 'isparta';
+import * as isparta  from 'isparta';
 import babelify  from 'babelify';
 import watchify  from 'watchify';
 import buffer  from 'vinyl-buffer';


### PR DESCRIPTION
Currently coverage is broken in the generator and `gulp coverage` fails with the following error:
```
[20:13:29] TypeError: Cannot read property 'Instrumenter' of undefined
    at Gulp._coverageOrig (...
```

The cause of this is that there is no default export for isparta. This PR imports the entire module under an isparta variable so the property reference to the instrumenter works as expected. 