### PR TITLE
Fix issue with npm whoami command

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/babel/generator-babel-boilerplate",
   "dependencies": {
-    "bluebird": "^2.9.34",
+    "bluebird": "^3.1.1",
     "chalk": "^1.1.0",
     "file": "^0.2.2",
     "git-config": "0.0.6",


### PR DESCRIPTION
This resolves an issue where the incorrect username would be returned
during initialization of the boilerplate. This is fixed by upgrading
Bluebird to v3.

Resolves #216