### PR TITLE
show jscs output when failing

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -40,6 +40,7 @@ function lint(files) {
     .pipe($.eslint.format())
     .pipe($.eslint.failOnError())
     .pipe($.jscs())
+    .pipe($.jscs.reporter())
     .pipe($.jscs.reporter('fail'))
     .on('error', onError);
 }


### PR DESCRIPTION
Show report when jscs fails as shown in example https://github.com/jscs-dev/gulp-jscs#reporting--fixing--failing-on-lint-error