### PR TITLE
Rewrite naming algorithm for package.json variables

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -81,6 +81,18 @@ module.exports = generators.Base.extend({
     return self.prompt(prompts).then(function(props) {
       self.user = jsonEscape(props.user);
       self.repo = jsonEscape(props.repo);
+
+      // Remove `.js` from the npm module name, per the "tips" section of the
+      // npm documentation: https://docs.npmjs.com/files/package.json#name
+      if (_.endsWith(self.repo, '.js')) {
+        self.moduleName = self.repo.slice(0, -3);
+      } else {
+        self.moduleName = self.repo;
+      }
+
+      // The mainFile, on the other hand, must always have an extension
+      self.entryFileName = self.moduleName + '.js';
+
       self.description = jsonEscape(props.description);
       self.author = jsonEscape(props.author);
       self.variable = props.variable;

--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -58,7 +58,7 @@ function lintGulpfile() {
 }
 
 function build() {
-  return gulp.src(path.join('src', config.entryFileName + '.js'))
+  return gulp.src(path.join('src', config.entryFileName))
     .pipe($.plumber())
     .pipe(webpackStream({
       output: {

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "<%= repo %>",
+  "name": "<%= moduleName %>",
   "version": "0.0.1",
   "description": "<%- description %>",
-  "main": "dist/<%= repo %>.js",
+  "main": "dist/<%= entryFileName %>",
   "scripts": {
     "test": "gulp",
     "lint": "gulp lint",
@@ -55,7 +55,7 @@
     "webpack-stream": "^3.1.0"
   },
   "babelBoilerplateOptions": {
-    "entryFileName": "<%= repo %>",
+    "entryFileName": "<%= entryFileName %>",
     "mainVarName": "<%= variable %>"
   }
 }


### PR DESCRIPTION
This has been a long time coming. Previously, if you set the repository name to be something with `.js` in it, the resulting `package.json` would have some weird values. For instance, the entryFileName would be `name.js.js`, and the name of the npm module itself would have `.js`.

This makes the behavior more predictable, and it should line up with what you want most of the time.