### PR TITLE
Ensure linting errors are all reported + linting fails build

### DIFF
--- a/app/templates/gulpfile.babel.js
+++ b/app/templates/gulpfile.babel.js
@@ -28,18 +28,12 @@ function cleanTmp(done) {
   del(['tmp']).then(() => done());
 }
 
-function onError() {
-  $.util.beep();
-}
-
 // Lint a set of files
 function lint(files) {
   return gulp.src(files)
-    .pipe($.plumber())
     .pipe($.eslint())
     .pipe($.eslint.format())
-    .pipe($.eslint.failOnError())
-    .on('error', onError);
+    .pipe($.eslint.failAfterError());
 }
 
 function lintSrc() {
@@ -56,7 +50,6 @@ function lintGulpfile() {
 
 function build() {
   return gulp.src(path.join('src', config.entryFileName))
-    .pipe($.plumber())
     .pipe(webpackStream({
       output: {
         filename: exportFileName + '.js',


### PR DESCRIPTION
This tidies up the linting task.

Previously, I was using `plumber` to make sure that all of the errors were reported in a given run of `npm run lint`. Now that we're only using ESLint, I can use `failAfterError` and get everything reported without the need for plumber.

This is great because it fixes the issue of plumber preventing builds from failing.

I also removed plumber from the build task, because there's no reason to not just blow up on errors there.