### PR TITLE
Fix naming algorithm issues

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -13,18 +13,13 @@ function jsonEscape(str) {
   return jsesc(str, {quotes: 'double'});
 }
 
-function generateName(str) {
-  str = _.chain(str)
-    .deburr()
-    .trim()
-    .replace(/\s/g, '-')
-    .value();
-  return str.toLowerCase();
-}
-
 module.exports = generators.Base.extend({
   initializing: function() {
     this.pkg = require('../package.json');
+
+    this.dirname = path.basename(this.destinationRoot());
+    this.dirnameNoJs = path.basename(this.dirname, '.js');
+    this.dirnameWithJs = this.dirnameNoJs + '.js';
   },
 
   prompting: function() {
@@ -58,7 +53,10 @@ module.exports = generators.Base.extend({
       type: 'input',
       name: 'repo',
       message: 'What is the repository/project name?',
-      default: generateName(this.appname)
+      // This default works when the directory was generated from a cloned
+      // repository, or when the user intends to make a repo with the same
+      // name as the directory. We assume this is the most common situation.
+      default: this.dirname
     }, {
       type: 'input',
       name: 'description',
@@ -73,7 +71,11 @@ module.exports = generators.Base.extend({
       type: 'input',
       name: 'variable',
       message: 'If there is one, what is the name of this project\'s main variable?',
-      default: _.camelCase(this.appname)
+      // The directory name – without `.js` – is likely to be the name of the
+      // main variable. For instance:
+      // `hello-there.js` => `helloThere`
+      // `hello-there` => `helloThere`
+      default: _.camelCase(this.dirnameNoJs)
     }];
 
     var self = this;
@@ -82,16 +84,15 @@ module.exports = generators.Base.extend({
         self.user = jsonEscape(props.user);
         self.repo = jsonEscape(props.repo);
 
-        // Remove `.js` from the npm module name, per the "tips" section of the
-        // npm documentation: https://docs.npmjs.com/files/package.json#name
-        if (_.endsWith(self.repo, '.js')) {
-          self.moduleName = self.repo.slice(0, -3);
-        } else {
-          self.moduleName = self.repo;
-        }
+        // A good candidate for the module name is the directory, which we assume
+        // to be derived from the repository name, stripped of any `.js` extension.
+        // The extension is stripped per the "tips" section of the npm docs:
+        // https://docs.npmjs.com/files/package.json#name
+        self.moduleName = jsonEscape(self.dirnameNoJs.toLowerCase());
 
-        // The mainFile, on the other hand, must always have an extension
-        self.entryFileName = self.moduleName + '.js';
+        // The mainFile, on the other hand, must always have an extension. Once
+        // again we derive this from the name of the directory.
+        self.fileName = jsonEscape(self.dirnameWithJs.toLowerCase());
 
         self.description = jsonEscape(props.description);
         self.author = jsonEscape(props.author);

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -2,7 +2,7 @@
   "name": "<%= moduleName %>",
   "version": "0.0.1",
   "description": "<%- description %>",
-  "main": "dist/<%= entryFileName %>",
+  "main": "dist/<%= fileName %>",
   "scripts": {
     "test": "gulp",
     "lint": "gulp lint",
@@ -55,7 +55,7 @@
     "webpack-stream": "^3.1.0"
   },
   "babelBoilerplateOptions": {
-    "entryFileName": "<%= entryFileName %>",
+    "entryFileName": "<%= fileName %>",
     "mainVarName": "<%= variable %>"
   }
 }


### PR DESCRIPTION
#346 fixed an issue where `npm` wouldn't even install. This fixes the incomplete work begun in #339, making the naming behave as I intended it to.

The algorithm is similar to the last one in that it begins with the directory that the project is in. Because most directories are the same as the repo name, this is fine, I think.

From there, four values need to be generated:

1. the npm module name
2. the file names
3. the repo name
4. the main variable name

The npm module name is a lowercased version of the directory without a `.js` extension. Here are a few examples:

`hello-there.js` => `hello-there`
`hello-there` => `hello-there`
`react.native-thing.js` => `react.native-thing`
`WhatTheModule` => `whatthemodule`

The file names follow the same algorithm as above, but *with* the extension. So...

`hello-there.js` => `hello-there.js`
`hello-there` => `hello-there.js`
`react.native-thing.js` => `react.native-thing.js`
`WhatTheModule` => `whatthemodule.js`

The repo is just the dirname directly (assuming the user used the default value).

And the variable name is the module name in camel case format.

Of course, all of these can be overridden in a straightforward way. This just updates the defaults to be a bit smarter.