### PR TITLE
Switch to gulp-watch

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -116,7 +116,7 @@ const watchFiles = ['src/**/*', 'test/**/*', 'package.json', '**/.eslintrc'];
 
 // Run the headless unit tests as you make changes.
 function watch() {
-  gulp.watch(watchFiles, ['test']);
+  $.watch(watchFiles, test);
 }
 
 function testBrowser() {
@@ -157,7 +157,7 @@ function testBrowser() {
     }, null, function() {
       if (firstBuild) {
         $.livereload.listen({port: 35729, host: 'localhost', start: true});
-        var watcher = gulp.watch(watchFiles, ['lint']);
+        watch();
       } else {
         $.livereload.reload('./tmp/__spec-build.js');
       }

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -42,6 +42,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
+    "gulp-watch": "^4.3.8",
     "isparta": "^4.0.0",
     "json-loader": "^0.5.3",
     "mocha": "^2.3.4",


### PR DESCRIPTION
Resolves #365 

--

the behavior is a little different in this implementation, since I can't specify a Gulp task to be run when the watched files change. I can either operate on the stream, or pass a cb to execute a single task. Since linting is 3 tasks, this is a little tricky. Hmmm...