### PR TITLE
Replace deprecated babel-preset-latest with babel-preset-env

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -26,7 +26,7 @@
     "babel-core": "6.14.0",
     "babel-loader": "6.2.5",
     "babel-polyfill": "6.13.0",
-    "babel-preset-latest": "6.14.0",
+    "babel-preset-env": "6.26.0",
     "babel-register": "6.14.0",
     "chai": "3.5.0",
     "del": "2.2.2",


### PR DESCRIPTION
Fixes #431  -- babel-preset-env is the suggested replacement for babel-preset-latest, according to https://babeljs.io/docs/plugins/preset-latest/

I made this change locally and `npm run test` passes, but I don't think that's actually doing much of a test. This is my first time contributing to a generator, so I need to figure out how to test it. 